### PR TITLE
Use bun instead of nodejs

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,18 +1,19 @@
-FROM oven/bun:debian
+FROM oven/bun:alpine
 
-RUN apt-get update
-RUN apt-get install -y wget gnupg2
+RUN apk update
+RUN apk upgrade
 
-# Install Chromium.
-RUN \
-  wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
-  apt-get update && \
-  apt-get install -y google-chrome-stable && \
-  rm -rf /var/lib/apt/lists/*
-
+RUN apk add chromium
 
 RUN mkdir /app
+
+COPY package.json /app/
+
+
+WORKDIR /app
+
+RUN bun pm trust protobufjs || true
+RUN bun install
 
 COPY index.js /app/
 COPY state.js /app/
@@ -21,11 +22,6 @@ COPY speech_google.js /app/
 COPY speech_whisper.js /app/
 COPY speech_openai.js /app/
 COPY languages.js /app/
-COPY package.json /app/
+COPY runbun.sh /app/
 
-WORKDIR /app
-
-RUN bun pm trust protobufjs || true
-RUN bun install
-
-CMD ["bun","index.js"]
+CMD ["runbun.sh"]

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,7 @@
-FROM node
+FROM oven/bun:debian
+
+RUN apt-get update
+RUN apt-get install -y wget gnupg2
 
 # Install Chromium.
 RUN \
@@ -22,6 +25,7 @@ COPY package.json /app/
 
 WORKDIR /app
 
-RUN npm install
+RUN bun pm trust protobufjs || true
+RUN bun install
 
-CMD ["node","index.js"]
+CMD ["bun","index.js"]

--- a/node/environment.js
+++ b/node/environment.js
@@ -127,3 +127,9 @@ exports.saveStateDir = _saveStateDir;
 const _freshStateOnStart = getBooleanEnvVariable(process.env.NO_SAVED_STATE, false);
 exports.freshStateOnStart = _freshStateOnStart;
 
+const _userAgent = getStringEnvVariable(process.env.USER_AGENT, null);
+exports.userAgent = _userAgent;
+
+const _chromiumPath = getStringEnvVariable(process.env.CHROMIUM_PATH, null);
+exports.chromiumPath = _chromiumPath;
+

--- a/node/index.js
+++ b/node/index.js
@@ -11,15 +11,34 @@ const speechGoogle = require('./speech_google');
 const speechOpenAI = require('./speech_openai');
 const { state } = require('./state');
 
+// see versions here: https://github.com/wppconnect-team/wa-version/tree/main/html
+const wwebVersion = '2.2412.54';
+
+const puppeteerOptions = {
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox']
+};
+
+if (env.chromiumPath) {
+    puppeteerOptions['executablePath'] = env.chromiumPath;
+}
+
+if (env.userAgent) {
+    puppeteerOptions.args.push(`--user-agent="${env.userAgent}"`);
+}
+
 // Setup options for the client and data path for the google chrome session
 const client = new Client({
     authStrategy: new LocalAuth({dataPath: env.chromeDataPath}),
-    puppeteer: {
-        headless: true,
-        args: ['--no-sandbox', '--disable-setuid-sandbox']
-    }
+    puppeteer: puppeteerOptions,
+    // Use a fixed, old webVersionCache to work with the latest WA version
+    // remove once whatsapp-web.js catches up.
+    // https://github.com/pedroslopez/whatsapp-web.js/issues/2789
+    webVersionCache: {
+        type: 'remote',
+        remotePath: `https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/${wwebVersion}.html`,
+    },
 });
-
 
 async function init() {
   

--- a/node/index.js
+++ b/node/index.js
@@ -309,11 +309,16 @@ async function ProcessVoiceMessage(message) {
             for (const result of data.results) {
                 const transcript = result.transcript;
                 let responseMessage = await voiceMessage.reply(languages.text.successHeader + transcript);
-                let id = getTimestampId(voiceMessage);
-                state.trackMessage(id, {
-                    messageId: responseMessage.id._serialized,
-                    chatId: chat.id._serialized,
-                });
+                try {
+                    let id = getTimestampId(voiceMessage);
+                    state.trackMessage(id, {
+                        messageId: responseMessage.id._serialized,
+                        chatId: chat.id._serialized,
+                    });
+                } catch (err) {
+                    console.log(err);
+                    console.log(err.stack);
+                }
             }
         })
         .catch((err) => {

--- a/node/package.json
+++ b/node/package.json
@@ -9,5 +9,8 @@
     "qrcode-terminal": "^0.12.0",
     "request": "^2.88.2",
     "whatsapp-web.js": "^1.19.4"
-  }
+  },
+  "trustedDependencies": [
+    "protobufjs"
+  ]
 }

--- a/node/runbun.sh
+++ b/node/runbun.sh
@@ -1,0 +1,3 @@
+#!/bin/env sh
+export CHROMIUM_PATH=$(which chromium)
+bun index.js

--- a/node/state.js
+++ b/node/state.js
@@ -8,7 +8,7 @@ class State {
   // Track message id by order of insertion.
   #transcribedMessagesIds = [];
   // Max number of messages to track.
-  transcribedMessagesCacheSize = 100;
+  #transcribedMessagesCacheSize = 100;
 
   // Set of chat with transcription disabled
   #chatTranscriptionsDisabled = {};
@@ -55,7 +55,7 @@ class State {
   trackMessage(id, data){
     this.#transcribedMessages[id] = data;
     this.#transcribedMessagesIds.push(id);
-    if (this.#transcribedMessagesIds.length > transcribedMessagesCacheSize){
+    if (this.#transcribedMessagesIds.length > this.#transcribedMessagesCacheSize){
       let toRemove = this.#transcribedMessagesIds.shift();
       delete this.#transcribedMessages[toRemove];
     }


### PR DESCRIPTION
[Bun](https://bun.sh) is way faster and than nodejs and it should have a smaller footprint. And is shiny and new :D

This change also uses the alpine base image, which is smaller than the ubuntu one.

All in all the difference is noticeable:

```
(main)> time docker build . -t node
[+] Building 161.3s (18/18) FINISHED

(bun)> docker build . -t bunbot
[+] Building 61.2s (22/22) FINISHED     

>docker image ls
REPOSITORY   TAG       IMAGE ID       CREATED              SIZE
bunbot       latest    0d5d94e68126   12 seconds ago       842MB
node         latest    ffa5358861d1   About a minute ago   2.46GB
```
I also moved the copy of `package.json` before the install phase so that it does not reinstall all the npms if we only modified the local js files.
